### PR TITLE
Add TSL2561 light sensor

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -25,6 +25,7 @@ lib_deps =
     Adafruit Unified Sensor
     DHT sensor library
     Adafruit DHT Unified
+    Adafruit TSL2561
 build_flags = -DASYNC_TCP_SSL_ENABLED
 ; These were used for debugging. I don't think I got debugging working though. q1 
 ;build_flags = -Og -ggdb -DGDBSTUB_FREERTOS=0 -DENABLE_GDB=1 -DDEBUG_ESP_PORT=Serial

--- a/src/hal.ino
+++ b/src/hal.ino
@@ -3,6 +3,7 @@
 #include <Vector.h>
 #include "sensor/SensorNode.hpp"
 #include "sensor/DhtSensor.hpp"
+#include "sensor/TslSensor.hpp"
 
 // TODO: Refactor MEASURE_INTERVAL to be a setting that is retrieved.
 const int MEASURE_INTERVAL = 1; // How often to poll DHT22 for temperature and humidity
@@ -12,6 +13,8 @@ unsigned long lastMeasureSent = 0;
 HomieSetting<long> dht11Setting("dht11_pin", "Which pin to use.");  // id, description
 HomieSetting<long> dht21Setting("dht21_pin", "Which pin to use.");  // id, description
 HomieSetting<long> dht22Setting("dht22_pin", "Which pin to use.");  // id, description
+HomieSetting<long> tsl_scl("tsl_scl", "Which pin to use for scl.");  // id, description
+HomieSetting<long> tsl_sda("tsl_sda", "Which pin to use for sda.");  // id, description
 
 std::vector<SensorNode*> sensors;
 
@@ -36,6 +39,12 @@ void setup() {
   dht22Setting.setDefaultValue(0).setValidator([] (long candidate) {
     return (candidate >= 0) && (candidate <= 100);
   }); 
+  tsl_scl.setDefaultValue(0).setValidator([] (long candidate) {
+    return (candidate >= 0) && (candidate <= 100);
+  }); 
+  tsl_sda.setDefaultValue(0).setValidator([] (long candidate) {
+    return (candidate >= 0) && (candidate <= 100);
+  }); 
   Homie.loadSettings();
 
   // Initialize any configured sensors.
@@ -47,6 +56,9 @@ void setup() {
     new DhtSensor(sensors, DHT21, "dht21_temperature", "dht21_humidity", dht21Setting.get());
   if(dht22Setting.wasProvided())
     new DhtSensor(sensors, DHT22, "dht22_temperature", "dht22_humidity", dht22Setting.get());
+  if(tsl_scl.wasProvided() && tsl_sda.wasProvided())
+    new TslSensor(sensors, "tsl_lux", tsl_scl.get(), tsl_sda.get()); 
+
 
   Homie.setup();
 }

--- a/src/sensor/SensorNode.hpp
+++ b/src/sensor/SensorNode.hpp
@@ -47,5 +47,85 @@ void SensorNode::readSensorAndReport() {
       this->setValue(String(reading));
       Homie.getLogger() << F("Temperature: ") << reading << " °C" << endl;
       break;
+    case SENSOR_TYPE_LIGHT:
+      reading = event.light;
+      this->setValue(String(reading));
+      Homie.getLogger() << F("Light      : ") << reading << " Lux" << endl;
+      break;
+    case SENSOR_TYPE_PRESSURE:
+      reading = event.pressure;
+      this->setValue(String(reading));
+      Homie.getLogger() << F("Pressure   : ") << reading << " hPa" << endl;
+      break;
+    case SENSOR_TYPE_VOLTAGE:
+      reading = event.voltage;
+      this->setValue(String(reading));
+      Homie.getLogger() << F("Voltage    : ") << reading << " V" << endl;
+      break;
+    case SENSOR_TYPE_CURRENT:
+      reading = event.current;
+      this->setValue(String(reading));
+      Homie.getLogger() << F("Current    : ") << reading << " mA" << endl;
+      break;
+    default:
+      Homie.getLogger() << F("Could not get sensor type. ") << endl;
+
+    // TODO: These are not floats. They should get their own readingSENSOR_TYPES.
+    /**
+    case SENSOR_TYPE_ACCELEROMETER:
+      reading = event.acceleration;
+      this->setValue(String(reading));
+      Homie.getLogger() << F("Acceleration: ") << reading << "m/s^2" << endl;
+      break;
+    case SENSOR_TYPE_MAGNETIC_FIELD:
+      reading = event.magnetic;
+      this->setValue(String(reading));
+      Homie.getLogger() << F("Magnetic: ") << reading << "uT" << endl;
+      break;
+    case SENSOR_TYPE_ORIENTATION:
+      reading = event.orientation;
+      this->setValue(String(reading));
+      Homie.getLogger() << F("Orientation: ") << reading << "degrees" << endl;
+      break;
+    case SENSOR_TYPE_GYROSCOPE:
+      reading = event.gyro;
+      this->setValue(String(reading));
+      Homie.getLogger() << F("Gyro: ") << reading << "rads/s" << endl;
+      break;
+    case SENSOR_TYPE_COLOR:
+      reading = event.color;
+      this->setValue(String(reading));
+      Homie.getLogger() << F("Color: ") << reading << "RGB" << endl;
+      break;
+    case SENSOR_TYPE_GRAVITY:
+      reading = event.acceleration;
+      this->setValue(String(reading));
+      Homie.getLogger() << F("Gravity: ") << reading << "m/s^2" << endl;
+      break;
+    case SENSOR_TYPE_LINEAR_ACCELERATION:
+      reading = event.acceleration;
+      this->setValue(String(reading));
+      Homie.getLogger() << F("Acceleration not including gravity: ") << reading << "m/s^2" << endl;
+      break;
+    */
+
+    // I'm not sure what to do with a proximity sensor. It wasn't in the 
+    // struct union: https://github.com/adafruit/Adafruit_Sensor/blob/master/Adafruit_Sensor.h
+    /*
+    case SENSOR_TYPE_PROXIMITY:
+      reading = event.temperature;
+      this->setValue(String(reading));
+      Homie.getLogger() << F("Temperature: ") << reading << " °C" << endl;
+      break;
+    */
+    // I'm not sure what to do with a rotation vector sensor. It wasn't in the 
+    // struct union: https://github.com/adafruit/Adafruit_Sensor/blob/master/Adafruit_Sensor.h
+    /*
+    case SENSOR_TYPE_ROTATION_VECTOR:
+      reading = event.temperature;
+      this->setValue(String(reading));
+      Homie.getLogger() << F("Temperature: ") << reading << " °C" << endl;
+      break;
+    */
   }
 }

--- a/src/sensor/TslSensor.hpp
+++ b/src/sensor/TslSensor.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <Adafruit_TSL2561_U.h> 
+#include <Homie.h>
+#include <Wire.h>
+#include "Constants.hpp"
+#include <ArduinoJson.h>
+
+class TslSensor {
+public:
+  TslSensor(std::vector<SensorNode*> &sensors, const char* id, uint8_t scl, uint8_t sda);
+};
+
+/**
+  @param sensors
+  @param id for the node.
+  @param pin that the sensor is plugged in to. 
+ */
+TslSensor::TslSensor(std::vector<SensorNode*> &sensors, const char* id, uint8_t scl, uint8_t sda) {
+    DynamicJsonBuffer parseJsonBuffer(JSON_OBJECT_SIZE(15));
+    Adafruit_TSL2561_Unified* tsl = new Adafruit_TSL2561_Unified(TSL2561_ADDR_FLOAT, 3); 
+    TwoWire *wire = new TwoWire();
+    wire->begin(scl,sda);
+    //pinMode(pin, OUTPUT);
+    tsl->begin(wire);
+    
+    Homie.getLogger() << id << " on scl: " << scl << " and sda: " << sda << endl;
+     
+    sensors.push_back(new SensorNode(id, "Lux", tsl));
+}


### PR DESCRIPTION
This adds support for the TSL2561 light sensor. It can be configured with: 
```json
{
    "settings": {
        "tsl_scl": SCL_PIN,
        "tsl_sda": SDA_PIN,
    }
}
```
For more context, you can checkout this issue: https://github.com/SciFiFarms/TechnoCore-PlatformIO/issues/4